### PR TITLE
[WIP] Add optional mandatory-users and mandatory-groups

### DIFF
--- a/src/bec_config_ss.erl
+++ b/src/bec_config_ss.erl
@@ -175,7 +175,11 @@ from_permission_type('REPO_READ')  -> read.
 -spec to_wz_branch_reviewer(map()) -> bec_wz_branch_reviewer_t:reviewer().
 to_wz_branch_reviewer(#{<<"paths">> := Paths} = R0) ->
   R = R0#{<<"paths">> => lists:sort([atomify_keys(P) || P <- Paths])},
-  atomify_keys(R).
+  Mandatory = #{<<"mandatory-users">>  => []
+              , <<"mandatory-groups">> => []
+              },
+  Merged = maps:merge(Mandatory, R),
+  atomify_keys(Merged).
 
 -spec atomify_keys(map()) -> map().
 atomify_keys(Map) ->

--- a/src/bec_wz_branch_reviewer_t.erl
+++ b/src/bec_wz_branch_reviewer_t.erl
@@ -13,10 +13,12 @@
 %%==============================================================================
 %% Types
 %%==============================================================================
--type reviewer() :: #{ 'branch-id' := bec_branch_t:id()
-                     , users       := [bec_wz_user_t:name()]
-                     , groups      := [bec_group_t:name()]
-                     , paths       := [bec_wz_path_t:path()]
+-type reviewer() :: #{ 'branch-id'        := bec_branch_t:id()
+                     , users              := [bec_wz_user_t:name()]
+                     , groups             := [bec_group_t:name()]
+                     , paths              := [bec_wz_path_t:path()]
+                     , 'mandatory-users'  := [bec_wz_user_t:name()]
+                     , 'mandatory-groups' := [bec_group_t:name()]
                      }.
 
 %%==============================================================================
@@ -34,24 +36,31 @@ from_map(#{ <<"refName">>           := RefName
           } = Map) ->
   %% filePathReviewers are not always present in the response from BitBucket
   FPR = maps:get(<<"filePathReviewers">>, Map, []),
-  #{ 'branch-id' => bec_wz_utils:strip_prefix(RefName)
-   , users       => lists:sort([bec_wz_user_t:from_map(U) || U <- Users])
-   , groups      => lists:sort(Groups)
-   , paths       => lists:sort([bec_wz_path_t:from_map(P) || P <- FPR])
+  MUsers = maps:get(<<"mandatoryUsers">>, Map, []),
+  MGroups = maps:get(<<"mandatoryGroups">>, Map, []),
+  #{ 'branch-id'        => bec_wz_utils:strip_prefix(RefName)
+   , users              => lists:sort([bec_wz_user_t:from_map(U) || U <- Users])
+   , groups             => lists:sort(Groups)
+   , paths              => lists:sort([bec_wz_path_t:from_map(P) || P <- FPR])
+   , 'mandatory-users'  => lists:sort([bec_wz_user_t:from_map(U)
+                                        || U <- MUsers])
+   , 'mandatory-groups' => lists:sort(MGroups)
    }.
 
 -spec to_map(reviewer()) -> map().
-to_map(#{ 'branch-id' := BranchId
-        , users       := Users
-        , groups      := Groups
-        , paths       := Paths
-        }) ->
+to_map(#{ 'branch-id'             := BranchId
+        , users                   := Users
+        , groups                  := Groups
+        , paths                   := Paths
+        } = Map) ->
+  MUsers = maps:get('mandatory-users', Map, []),
+  MGroups = maps:get('mandatory-groups', Map, []),
   #{ <<"refName">>               => bec_wz_utils:add_prefix(BranchId)
    , <<"users">>                 => [bec_wz_user_t:to_map(U) || U <- Users]
    , <<"groups">>                => Groups
    , <<"filePathReviewers">>     => [bec_wz_path_t:to_map(P) || P <- Paths]
-   , <<"mandatoryUsers">>        => []
-   , <<"mandatoryGroups">>       => []
+   , <<"mandatoryUsers">>        => [bec_wz_user_t:to_map(U) || U <- MUsers]
+   , <<"mandatoryGroups">>       => MGroups
    , <<"topSuggestedReviewers">> => 0
    , <<"daysInPast">>            => 0
    }.

--- a/test/bitbucket_api_SUITE.erl
+++ b/test/bitbucket_api_SUITE.erl
@@ -12,6 +12,7 @@
         , set_default_branch/1
         , get_wz_branch_reviewers/1
         , get_wz_branch_reviewers_when_none_configured/1
+        , get_wz_branch_reviewers_with_mandatory/1
         ]).
 
 -include_lib("common_test/include/ct.hrl").


### PR DESCRIPTION
[WIP] - more tests will follow

Right now we don't have ability to define mandatory users and groups in the `wz-branch-reviewers` section. Proposed syntax is as follows:

```yaml
wz-branch-reviewers:
  - branch-id: master
    users: []
    groups: []
    paths: []
    mandatory-users: [user.a]
    mandatory-groups: [group.a]
```

Since lots of projects are already using BEC, the new "mandatory-" keywords will be optional to add, not to break existing configs.